### PR TITLE
Added some endpoints, cleaned up some details to API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,7 @@ readability.
 
 1. Install [prmd][2] per their instructions.
 2. From root of `online-ratings`, run
-   `prmd combine --meta docs/meta.yml --output docs/schema.json docs/schemata`
-3. From root of `online-ratings`, run `prmd doc --output docs/api.md docs/schema.json`
+   `prmd combine --meta docs/meta.yml docs/schemata | prmd verify | prmd doc > docs/api.md`
 
 [JSON Schema][3] is the general format used for types and [JSON Hyper-Schema][4] is used for
 endpoint definitions.

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,18 +7,112 @@ Loosely based off the example in the README
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **[black_id](#resource-player)** | *number* | this could be a uuid to make it db agnostic | `42.0` |
-| **date_played** | *date-time* |  | `"2015-01-01T12:00:00Z"` |
-| **game_record** | *string* |  | `"<raw sgf string>"` |
-| **game_server** | *string* |  | `"KGS"` |
-| **rated** | *boolean* |  | `true` |
-| **[white_id](#resource-player)** | *number* | this could be a uuid to make it db agnostic | `42.0` |
+| **[black_id](#resource-player)** | *number* | black player's id | `42.0` |
+| **date_played** | *date-time* | time the game was played | `"2015-01-01T12:00:00Z"` |
+| **game_record** | *string* | game record in SGF | `"<raw sgf string>"` |
+| **game_server** | *string* | game server id | `"KGS"` |
+| **id** | *number* | this could be a uuid to make it db agnostic | `42.0` |
+| **rated** | *boolean* | whether this was a rated game (on the server?) | `true` |
+| **[white_id](#resource-player)** | *number* | white player's id | `42.0` |
+
+### Game Creation
+
+Report a game result
+
+```
+POST /api/v1/games
+```
+
+#### Required Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **auth:black_token** | *uuid* | secret token for black player | `"01234567-89ab-cdef-0123-456789abcdef"` |
+| **auth:server_token** | *uuid* | secret server token | `"01234567-89ab-cdef-0123-456789abcdef"` |
+| **auth:white_token** | *uuid* | secret token for white player | `"01234567-89ab-cdef-0123-456789abcdef"` |
+| **game:black_id** | *number* | black player's id | `42.0` |
+| **game:date_played** | *date-time* | time the game was played | `"2015-01-01T12:00:00Z"` |
+| **game:game_record** | *string* | game record in SGF | `"<raw sgf string>"` |
+| **game:game_server** | *string* | game server id | `"KGS"` |
+| **game:rated** | *boolean* | whether this was a rated game (on the server?) | `true` |
+| **game:white_id** | *number* | white player's id | `42.0` |
+
+
+
+#### Curl Example
+
+```bash
+$ curl -n -X POST http://dev.usgo.org/api/v1/games \
+  -d '{
+  "game": {
+    "black_id": 42.0,
+    "white_id": 42.0,
+    "game_server": "KGS",
+    "rated": true,
+    "date_played": "2015-01-01T12:00:00Z",
+    "game_record": "<raw sgf string>"
+  },
+  "auth": {
+    "server_token": "01234567-89ab-cdef-0123-456789abcdef",
+    "black_token": "01234567-89ab-cdef-0123-456789abcdef",
+    "white_token": "01234567-89ab-cdef-0123-456789abcdef"
+  }
+}' \
+  -H "Content-Type: application/json"
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 201 Created
+```
+
+```json
+{
+  "id": 42.0
+}
+```
+
+### Game Read
+
+Get a game result by id
+
+```
+GET /api/v1/games/{game_id}
+```
+
+
+#### Curl Example
+
+```bash
+$ curl -n http://dev.usgo.org/api/v1/games/$GAME_ID
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 200 OK
+```
+
+```json
+{
+  "id": 42.0,
+  "black_id": 42.0,
+  "white_id": 42.0,
+  "game_server": "KGS",
+  "rated": true,
+  "date_played": "2015-01-01T12:00:00Z",
+  "game_record": "<raw sgf string>"
+}
+```
 
 
 ## <a name="resource-player">Player</a>
 
 
-I copied the database table here, didn't document any endpoints here.
+I copied the database table here.
 
 ### Attributes
 
@@ -28,5 +122,36 @@ I copied the database table here, didn't document any endpoints here.
 | **name** | *string* | should this be expanded to first_name, last_name? | `"example"` |
 | **server_id** | *number* | not sure if this should be exposed, im just copying the table definition | `42.0` |
 | **token** | *uuid* | im totally guessing that this is a uuid | `"01234567-89ab-cdef-0123-456789abcdef"` |
+
+### Player Read
+
+Get a player by id
+
+```
+GET /api/v1/players/{player_id}
+```
+
+
+#### Curl Example
+
+```bash
+$ curl -n http://dev.usgo.org/api/v1/players/$PLAYER_ID
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 200 OK
+```
+
+```json
+{
+  "id": 42.0,
+  "name": "example",
+  "server_id": 42.0,
+  "token": "01234567-89ab-cdef-0123-456789abcdef"
+}
+```
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -106,7 +106,7 @@ HTTP/1.1 200 OK
 
 ### Game SGF
 
-Fetch the sgf contents
+Fetch a link to the sgf contents
 
 ```
 GET /api/v1/games/{game_id}/sgf
@@ -127,9 +127,7 @@ HTTP/1.1 200 OK
 ```
 
 ```json
-{
-  "data": "sgf string"
-}
+http://example.com/link/to/game.sgf
 ```
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,19 +1,18 @@
 ## <a name="resource-game">Game</a>
 
 
-Loosely based off the example in the README
+A game played between two players
 
 ### Attributes
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **[black_id](#resource-player)** | *integer* | black player's id | `42` |
+| **black_id** | *integer* | black player id | `42` |
 | **date_played** | *date-time* | time the game was played | `"2015-01-01T12:00:00Z"` |
 | **game_record** | *string* | game record in SGF | `"<raw sgf string>"` |
 | **game_server** | *string* | game server id | `"KGS"` |
-| **id** | *integer* | this could be a uuid to make it db agnostic | `42` |
-| **rated** | *boolean* | whether this was a rated game (on the server?) | `true` |
-| **[white_id](#resource-player)** | *integer* | white player's id | `42` |
+| **id** | *integer* | game id | `42` |
+| **white_id** | *integer* | white player id | `42` |
 
 ### Game Creation
 
@@ -27,13 +26,18 @@ POST /api/v1/games
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **black_id** | *integer* | black player's id | `42` |
+| **black_id** | *integer* | black player id | `42` |
 | **date_played** | *date-time* | time the game was played | `"2015-01-01T12:00:00Z"` |
-| **game_record** | *string* | game record in SGF | `"<raw sgf string>"` |
 | **game_server** | *string* | game server id | `"KGS"` |
-| **rated** | *boolean* | whether this was a rated game (on the server?) | `true` |
-| **white_id** | *integer* | white player's id | `42` |
+| **white_id** | *integer* | white player id | `42` |
 
+
+#### Optional Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **game_record** | *string* | game record in SGF | `"<raw sgf string>"` |
+| **game_url** | *string* | game url | `"http://example.com/game.sgf"` |
 
 
 #### Curl Example
@@ -44,9 +48,9 @@ $ curl -n -X POST http://dev.usgo.org/api/v1/games \
   "black_id": 42,
   "white_id": 42,
   "game_server": "KGS",
-  "rated": true,
   "date_played": "2015-01-01T12:00:00Z",
-  "game_record": "<raw sgf string>"
+  "game_record": "<raw sgf string>",
+  "game_url": "http://example.com/game.sgf"
 }' \
   -H "Content-Type: application/json" \
   -H "X-Auth-Server-Token: <secret server token>" \
@@ -95,9 +99,36 @@ HTTP/1.1 200 OK
   "black_id": 42,
   "white_id": 42,
   "game_server": "KGS",
-  "rated": true,
   "date_played": "2015-01-01T12:00:00Z",
   "game_record": "<raw sgf string>"
+}
+```
+
+### Game SGF
+
+Fetch the sgf contents
+
+```
+GET /api/v1/games/{game_id}/sgf
+```
+
+
+#### Curl Example
+
+```bash
+$ curl -n http://dev.usgo.org/api/v1/games/$GAME_ID/sgf
+```
+
+
+#### Response Example
+
+```
+HTTP/1.1 200 OK
+```
+
+```json
+{
+  "data": "sgf string"
 }
 ```
 
@@ -105,16 +136,14 @@ HTTP/1.1 200 OK
 ## <a name="resource-player">Player</a>
 
 
-I copied the database table here.
+An online player
 
 ### Attributes
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **id** | *integer* | this could be a uuid to make it db agnostic | `42` |
-| **name** | *string* | should this be expanded to first_name, last_name? | `"example"` |
-| **server_id** | *integer* | not sure if this should be exposed, im just copying the table definition | `42` |
-| **token** | *uuid* | im totally guessing that this is a uuid | `"01234567-89ab-cdef-0123-456789abcdef"` |
+| **id** | *integer* | player id | `42` |
+| **name** | *string* | name of the player | `"example"` |
 
 ### Player Read
 
@@ -141,9 +170,7 @@ HTTP/1.1 200 OK
 ```json
 {
   "id": 42,
-  "name": "example",
-  "server_id": 42,
-  "token": "01234567-89ab-cdef-0123-456789abcdef"
+  "name": "example"
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,13 +7,13 @@ Loosely based off the example in the README
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **[black_id](#resource-player)** | *number* | black player's id | `42.0` |
+| **[black_id](#resource-player)** | *integer* | black player's id | `42` |
 | **date_played** | *date-time* | time the game was played | `"2015-01-01T12:00:00Z"` |
 | **game_record** | *string* | game record in SGF | `"<raw sgf string>"` |
 | **game_server** | *string* | game server id | `"KGS"` |
-| **id** | *number* | this could be a uuid to make it db agnostic | `42.0` |
+| **id** | *integer* | this could be a uuid to make it db agnostic | `42` |
 | **rated** | *boolean* | whether this was a rated game (on the server?) | `true` |
-| **[white_id](#resource-player)** | *number* | white player's id | `42.0` |
+| **[white_id](#resource-player)** | *integer* | white player's id | `42` |
 
 ### Game Creation
 
@@ -27,15 +27,12 @@ POST /api/v1/games
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **auth:black_token** | *uuid* | secret token for black player | `"01234567-89ab-cdef-0123-456789abcdef"` |
-| **auth:server_token** | *uuid* | secret server token | `"01234567-89ab-cdef-0123-456789abcdef"` |
-| **auth:white_token** | *uuid* | secret token for white player | `"01234567-89ab-cdef-0123-456789abcdef"` |
-| **game:black_id** | *number* | black player's id | `42.0` |
-| **game:date_played** | *date-time* | time the game was played | `"2015-01-01T12:00:00Z"` |
-| **game:game_record** | *string* | game record in SGF | `"<raw sgf string>"` |
-| **game:game_server** | *string* | game server id | `"KGS"` |
-| **game:rated** | *boolean* | whether this was a rated game (on the server?) | `true` |
-| **game:white_id** | *number* | white player's id | `42.0` |
+| **black_id** | *integer* | black player's id | `42` |
+| **date_played** | *date-time* | time the game was played | `"2015-01-01T12:00:00Z"` |
+| **game_record** | *string* | game record in SGF | `"<raw sgf string>"` |
+| **game_server** | *string* | game server id | `"KGS"` |
+| **rated** | *boolean* | whether this was a rated game (on the server?) | `true` |
+| **white_id** | *integer* | white player's id | `42` |
 
 
 
@@ -44,21 +41,17 @@ POST /api/v1/games
 ```bash
 $ curl -n -X POST http://dev.usgo.org/api/v1/games \
   -d '{
-  "game": {
-    "black_id": 42.0,
-    "white_id": 42.0,
-    "game_server": "KGS",
-    "rated": true,
-    "date_played": "2015-01-01T12:00:00Z",
-    "game_record": "<raw sgf string>"
-  },
-  "auth": {
-    "server_token": "01234567-89ab-cdef-0123-456789abcdef",
-    "black_token": "01234567-89ab-cdef-0123-456789abcdef",
-    "white_token": "01234567-89ab-cdef-0123-456789abcdef"
-  }
+  "black_id": 42,
+  "white_id": 42,
+  "game_server": "KGS",
+  "rated": true,
+  "date_played": "2015-01-01T12:00:00Z",
+  "game_record": "<raw sgf string>"
 }' \
-  -H "Content-Type: application/json"
+  -H "Content-Type: application/json" \
+  -H "X-Auth-Server-Token: <secret server token>" \
+  -H "X-Auth-Black-Player-Token: <secret token for black player>" \
+  -H "X-Auth-White-Player-Token: <secret token for white player>"
 ```
 
 
@@ -70,7 +63,7 @@ HTTP/1.1 201 Created
 
 ```json
 {
-  "id": 42.0
+  "id": 42
 }
 ```
 
@@ -98,9 +91,9 @@ HTTP/1.1 200 OK
 
 ```json
 {
-  "id": 42.0,
-  "black_id": 42.0,
-  "white_id": 42.0,
+  "id": 42,
+  "black_id": 42,
+  "white_id": 42,
   "game_server": "KGS",
   "rated": true,
   "date_played": "2015-01-01T12:00:00Z",
@@ -118,7 +111,7 @@ I copied the database table here.
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **id** | *number* | this could be a uuid to make it db agnostic | `42.0` |
+| **id** | *integer* | this could be a uuid to make it db agnostic | `42` |
 | **name** | *string* | should this be expanded to first_name, last_name? | `"example"` |
 | **server_id** | *number* | not sure if this should be exposed, im just copying the table definition | `42.0` |
 | **token** | *uuid* | im totally guessing that this is a uuid | `"01234567-89ab-cdef-0123-456789abcdef"` |
@@ -147,7 +140,7 @@ HTTP/1.1 200 OK
 
 ```json
 {
-  "id": 42.0,
+  "id": 42,
   "name": "example",
   "server_id": 42.0,
   "token": "01234567-89ab-cdef-0123-456789abcdef"

--- a/docs/api.md
+++ b/docs/api.md
@@ -127,7 +127,7 @@ HTTP/1.1 200 OK
 ```
 
 ```json
-http://example.com/link/to/game.sgf
+<sgf contents>
 ```
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -113,7 +113,7 @@ I copied the database table here.
 | ------- | ------- | ------- | ------- |
 | **id** | *integer* | this could be a uuid to make it db agnostic | `42` |
 | **name** | *string* | should this be expanded to first_name, last_name? | `"example"` |
-| **server_id** | *number* | not sure if this should be exposed, im just copying the table definition | `42.0` |
+| **server_id** | *integer* | not sure if this should be exposed, im just copying the table definition | `42` |
 | **token** | *uuid* | im totally guessing that this is a uuid | `"01234567-89ab-cdef-0123-456789abcdef"` |
 
 ### Player Read
@@ -142,7 +142,7 @@ HTTP/1.1 200 OK
 {
   "id": 42,
   "name": "example",
-  "server_id": 42.0,
+  "server_id": 42,
   "token": "01234567-89ab-cdef-0123-456789abcdef"
 }
 ```

--- a/docs/meta.yml
+++ b/docs/meta.yml
@@ -1,3 +1,6 @@
+id: online_ratings
+title: Online Ratings API Documentation
+description: Endpoints to submit games to AGA
 links:
-  - href: http://dev.usgo.org:8080
+  - href: http://dev.usgo.org
     rel: self

--- a/docs/overrides.css
+++ b/docs/overrides.css
@@ -1,3 +1,1 @@
-/*.toctree-l1 li { display: none }*/
-/*.toctree-l1 .toctree-l3 { display: block }*/
 .wy-nav-content { max-width: 900px }

--- a/docs/schemata/game.yml
+++ b/docs/schemata/game.yml
@@ -78,16 +78,12 @@ links:
 
 - href: /api/v1/games/{(%2Fschemata%2Fgame%23%2Fdefinitions%2Fidentity)}/sgf
   method: GET
-  description: Fetch the sgf contents
+  description: Fetch a link to the sgf contents
   rel: detail
   title: SGF
-  targetSchema:
-    type: object
-    properties:
-      data:
-        type: string
-        description: sgf string
-        example: sgf string
+  response_example:
+    head: HTTP/1.1 200 OK
+    body: http://example.com/link/to/game.sgf
 
 type: object
 properties:

--- a/docs/schemata/game.yml
+++ b/docs/schemata/game.yml
@@ -3,30 +3,24 @@ $schema: http://json-schema.org/draft-04/hyper-schema
 
 id: schemata/game
 title: Game
-description: |-
-  Loosely based off the example in the README
+description: A game played between two players
 
 definitions:
   identity:
-    anyOf:
-      - $ref: /schemata/game#/definitions/id
+    $ref: /schemata/game#/definitions/id
   id:
     type: integer
-    description: |-
-      this could be a uuid to make it db agnostic
+    description: game id
   black_id:
-    description: black player's id
-    $ref: /schemata/player#/definitions/id
+    type: integer
+    description: black player id
   white_id:
-    description: white player's id
-    $ref: /schemata/player#/definitions/id
+    type: integer
+    description: white player id
   game_server:
     type: string
     description: game server id
     example: KGS
-  rated:
-    type: boolean
-    description: whether this was a rated game (on the server?)
   date_played:
     type: string
     description: time the game was played
@@ -35,6 +29,10 @@ definitions:
     type: string
     description: game record in SGF
     example: <raw sgf string>
+  game_url:
+    type: string
+    description: game url
+    example: http://example.com/game.sgf
 
 links:
 - href: /api/v1/games
@@ -48,9 +46,7 @@ links:
       - black_id
       - white_id
       - game_server
-      - rated
       - date_played
-      - game_record
     properties:
       black_id:
         $ref: /schemata/game#/definitions/black_id
@@ -58,12 +54,12 @@ links:
         $ref: /schemata/game#/definitions/white_id
       game_server:
         $ref: /schemata/game#/definitions/game_server
-      rated:
-        $ref: /schemata/game#/definitions/rated
       date_played:
         $ref: /schemata/game#/definitions/date_played
       game_record:
         $ref: /schemata/game#/definitions/game_record
+      game_url:
+        $ref: /schemata/game#/definitions/game_url
   targetSchema:
     type: object
     properties:
@@ -74,11 +70,24 @@ links:
     X-Auth-Black-Player-Token: <secret token for black player>
     X-Auth-White-Player-Token: <secret token for white player>
 
-- href: /api/v1/games/{game_id}
+- href: /api/v1/games/{(%2Fschemata%2Fgame%23%2Fdefinitions%2Fidentity)}
   method: GET
   description: Get a game result by id
   rel: self
   title: Read
+
+- href: /api/v1/games/{(%2Fschemata%2Fgame%23%2Fdefinitions%2Fidentity)}/sgf
+  method: GET
+  description: Fetch the sgf contents
+  rel: detail
+  title: SGF
+  targetSchema:
+    type: object
+    properties:
+      data:
+        type: string
+        description: sgf string
+        example: sgf string
 
 type: object
 properties:
@@ -90,8 +99,6 @@ properties:
     $ref: /schemata/game#/definitions/white_id
   game_server:
     $ref: /schemata/game#/definitions/game_server
-  rated:
-    $ref: /schemata/game#/definitions/rated
   date_played:
     $ref: /schemata/game#/definitions/date_played
   game_record:

--- a/docs/schemata/game.yml
+++ b/docs/schemata/game.yml
@@ -6,20 +6,103 @@ title: Game
 description: |-
   Loosely based off the example in the README
 
-type: object
-properties:
+definitions:
+  identity:
+    anyOf:
+      - $ref: /schemata/game#/definitions/id
+  id:
+    type: number
+    description: |-
+      this could be a uuid to make it db agnostic
   black_id:
-    $ref: /schemata/player#/properties/id
+    description: black player's id
+    $ref: /schemata/player#/definitions/id
   white_id:
-    $ref: /schemata/player#/properties/id
+    description: white player's id
+    $ref: /schemata/player#/definitions/id
   game_server:
     type: string
+    description: game server id
     example: KGS
   rated:
     type: boolean
+    description: whether this was a rated game (on the server?)
   date_played:
     type: string
+    description: time the game was played
     format: date-time
   game_record:
     type: string
+    description: game record in SGF
     example: <raw sgf string>
+
+links:
+- href: /api/v1/games
+  method: POST
+  description: Report a game result
+  rel: create
+  title: Creation
+  schema:
+    type: object
+    required:
+      - game
+      - auth
+    properties:
+      game:
+        type: object
+        properties:
+          black_id:
+            $ref: /schemata/game#/definitions/black_id
+          white_id:
+            $ref: /schemata/game#/definitions/white_id
+          game_server:
+            $ref: /schemata/game#/definitions/game_server
+          rated:
+            $ref: /schemata/game#/definitions/rated
+          date_played:
+            $ref: /schemata/game#/definitions/date_played
+          game_record:
+            $ref: /schemata/game#/definitions/game_record
+      auth:
+        type: object
+        properties:
+          server_token:
+            type: string
+            format: uuid
+            description: secret server token
+          black_token:
+            type: string
+            format: uuid
+            description: secret token for black player
+          white_token:
+            type: string
+            format: uuid
+            description: secret token for white player
+  targetSchema:
+    type: object
+    properties:
+      id:
+        $ref: /schemata/game#/definitions/id
+
+- href: /api/v1/games/{game_id}
+  method: GET
+  description: Get a game result by id
+  rel: self
+  title: Read
+
+type: object
+properties:
+  id:
+    $ref: /schemata/game#/definitions/id
+  black_id:
+    $ref: /schemata/game#/definitions/black_id
+  white_id:
+    $ref: /schemata/game#/definitions/white_id
+  game_server:
+    $ref: /schemata/game#/definitions/game_server
+  rated:
+    $ref: /schemata/game#/definitions/rated
+  date_played:
+    $ref: /schemata/game#/definitions/date_played
+  game_record:
+    $ref: /schemata/game#/definitions/game_record

--- a/docs/schemata/game.yml
+++ b/docs/schemata/game.yml
@@ -83,7 +83,7 @@ links:
   title: SGF
   response_example:
     head: HTTP/1.1 200 OK
-    body: http://example.com/link/to/game.sgf
+    body: <sgf contents>
 
 type: object
 properties:

--- a/docs/schemata/game.yml
+++ b/docs/schemata/game.yml
@@ -11,7 +11,7 @@ definitions:
     anyOf:
       - $ref: /schemata/game#/definitions/id
   id:
-    type: number
+    type: integer
     description: |-
       this could be a uuid to make it db agnostic
   black_id:
@@ -45,44 +45,34 @@ links:
   schema:
     type: object
     required:
-      - game
-      - auth
+      - black_id
+      - white_id
+      - game_server
+      - rated
+      - date_played
+      - game_record
     properties:
-      game:
-        type: object
-        properties:
-          black_id:
-            $ref: /schemata/game#/definitions/black_id
-          white_id:
-            $ref: /schemata/game#/definitions/white_id
-          game_server:
-            $ref: /schemata/game#/definitions/game_server
-          rated:
-            $ref: /schemata/game#/definitions/rated
-          date_played:
-            $ref: /schemata/game#/definitions/date_played
-          game_record:
-            $ref: /schemata/game#/definitions/game_record
-      auth:
-        type: object
-        properties:
-          server_token:
-            type: string
-            format: uuid
-            description: secret server token
-          black_token:
-            type: string
-            format: uuid
-            description: secret token for black player
-          white_token:
-            type: string
-            format: uuid
-            description: secret token for white player
+      black_id:
+        $ref: /schemata/game#/definitions/black_id
+      white_id:
+        $ref: /schemata/game#/definitions/white_id
+      game_server:
+        $ref: /schemata/game#/definitions/game_server
+      rated:
+        $ref: /schemata/game#/definitions/rated
+      date_played:
+        $ref: /schemata/game#/definitions/date_played
+      game_record:
+        $ref: /schemata/game#/definitions/game_record
   targetSchema:
     type: object
     properties:
       id:
         $ref: /schemata/game#/definitions/id
+  http_header:
+    X-Auth-Server-Token: <secret server token>
+    X-Auth-Black-Player-Token: <secret token for black player>
+    X-Auth-White-Player-Token: <secret token for white player>
 
 - href: /api/v1/games/{game_id}
   method: GET

--- a/docs/schemata/player.yml
+++ b/docs/schemata/player.yml
@@ -11,7 +11,7 @@ definitions:
     anyOf:
       - $ref: /schemata/player#/definitions/id
   id:
-    type: number
+    type: integer
     description: |-
       this could be a uuid to make it db agnostic
   name:

--- a/docs/schemata/player.yml
+++ b/docs/schemata/player.yml
@@ -19,7 +19,7 @@ definitions:
     description: |-
       should this be expanded to first_name, last_name?
   server_id:
-    type: number
+    type: integer
     description: |-
       not sure if this should be exposed, im just copying the table definition
   token:

--- a/docs/schemata/player.yml
+++ b/docs/schemata/player.yml
@@ -3,33 +3,20 @@ $schema: http://json-schema.org/draft-04/hyper-schema
 
 id: schemata/player
 title: Player
-description: |-
-  I copied the database table here.
+description: An online player
 
 definitions:
   identity:
-    anyOf:
-      - $ref: /schemata/player#/definitions/id
+    $ref: /schemata/player#/definitions/id
   id:
     type: integer
-    description: |-
-      this could be a uuid to make it db agnostic
+    description: player id
   name:
     type: string
-    description: |-
-      should this be expanded to first_name, last_name?
-  server_id:
-    type: integer
-    description: |-
-      not sure if this should be exposed, im just copying the table definition
-  token:
-    type: string
-    format: uuid
-    description:
-      im totally guessing that this is a uuid
+    description: name of the player
 
 links:
-- href: /api/v1/players/{player_id}
+- href: /api/v1/players/{(%2Fschemata%2Fplayer%23%2Fdefinitions%2Fidentity)}
   method: GET
   description: Get a player by id
   rel: self
@@ -41,7 +28,3 @@ properties:
     $ref: /schemata/player#/definitions/id
   name:
     $ref: /schemata/player#/definitions/name
-  server_id:
-    $ref: /schemata/player#/definitions/server_id
-  token:
-    $ref: /schemata/player#/definitions/token

--- a/docs/schemata/player.yml
+++ b/docs/schemata/player.yml
@@ -4,10 +4,12 @@ $schema: http://json-schema.org/draft-04/hyper-schema
 id: schemata/player
 title: Player
 description: |-
-  I copied the database table here, didn't document any endpoints here.
+  I copied the database table here.
 
-type: object
-properties:
+definitions:
+  identity:
+    anyOf:
+      - $ref: /schemata/player#/definitions/id
   id:
     type: number
     description: |-
@@ -25,3 +27,21 @@ properties:
     format: uuid
     description:
       im totally guessing that this is a uuid
+
+links:
+- href: /api/v1/players/{player_id}
+  method: GET
+  description: Get a player by id
+  rel: self
+  title: Read
+
+type: object
+properties:
+  id:
+    $ref: /schemata/player#/definitions/id
+  name:
+    $ref: /schemata/player#/definitions/name
+  server_id:
+    $ref: /schemata/player#/definitions/server_id
+  token:
+    $ref: /schemata/player#/definitions/token


### PR DESCRIPTION
In this PR:
* Cleaned up the schema somewhat so that it was more likely to pass `prmd verify`.
    * At present, it doesn't verify all the way because I was doing an FK link with `black_id` and `white_id`.  `prmd` is pretty opinionated about this.
* Added a few endpoints.  I omitted a few endpoints because they seemed duplicative.
    * POST /api/v1/games Report a game result.
        * Added
    * GET /api/v1/games/<game_id> Get a game result by ID
        * Added
    * GET /api/v1/games/<game_id>/sgf Get a game's SGF file by ID
        * Skipped.  Seems duplicative with the other GET.
    * GET /api/v1/players/<player_id> Get a player by ID
        * Added
    * GET /api/v1/players?token=<token> Get a player by their secret token.
        * Skipped.  Seems duplicative with player GET.
* [API docs looks like this now](http://duckpunch.github.io/online-ratings/api/)
    * I'm in favor of something that resembles {API/spec/contract}-driven-development.  In other words, we work out the details of API semantics before implementing them.
* I tried to rebase and failed :(
    * If this bugs you, I can try to fix it before the merge.