### PR TITLE
a placeholder of sorts for tournaments

### DIFF
--- a/web/app/models.py
+++ b/web/app/models.py
@@ -11,7 +11,7 @@ roles_users = db.Table(
     'roles_users',
     db.Column('user_id', db.Integer(), db.ForeignKey('myuser.id')),
     db.Column('role_id', db.Integer(), db.ForeignKey('role.id'))
-) 
+)
 
 go_server_admins = db.Table(
     'go_server_admin',
@@ -118,7 +118,7 @@ class Rating(db.Model):
     rating = db.Column(db.Float)
     created = db.Column(db.DateTime, onupdate=datetime.datetime.now)
     def __str__(self):
-        return "(%f, sigma %f) for user %d" % (self.rating, self.sigma, self.user_id) 
+        return "(%f, sigma %f) for user %d" % (self.rating, self.sigma, self.user_id)
 
 class Game(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -167,5 +167,17 @@ class Game(db.Model):
             "rated": self.rated,
         }
 
+
+class Tournament(db.Model):
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    event_name = db.Column(db.String(80))
+    start_date = db.column(db.DateTime())
+    venue = db.column(db.String(80))
+    director = db.column(db.String(80))
+    pairing = db.column(db.String(80))
+    rule_set = db.column(db.String(80))
+
+    def __str__(self):
+        return "Tournament: {} \n\tEvent held on: {}\n\tEvent held at: {}\n\tEvent director: {}\n\tEvent pairing: {}\n\tEvent rule set: {}".format(self.event_name, self.start_date, self.venue, self.director, self.rule_set)
 # Setup Flask-Security
 user_datastore = SQLAlchemyUserDatastore(db, User, Role)

--- a/web/app/models.py
+++ b/web/app/models.py
@@ -171,11 +171,11 @@ class Game(db.Model):
 class Tournament(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     event_name = db.Column(db.String(80))
-    start_date = db.column(db.DateTime())
-    venue = db.column(db.String(80))
-    director = db.column(db.String(80))
-    pairing = db.column(db.String(80))
-    rule_set = db.column(db.String(80))
+    start_date = db.Column(db.DateTime())
+    venue = db.Column(db.String(80))
+    director = db.Column(db.String(80))
+    pairing = db.Column(db.String(80))
+    rule_set = db.Column(db.String(80))
 
     def __str__(self):
         return "Tournament: {} \n\tEvent held on: {}\n\tEvent held at: {}\n\tEvent director: {}\n\tEvent pairing: {}\n\tEvent rule set: {}".format(self.event_name, self.start_date, self.venue, self.director, self.rule_set)

--- a/web/app/templates/tournament_index.html
+++ b/web/app/templates/tournament_index.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+<h1>Tournaments:</h1>
+
+{% block content %}
+  {% for tournament in tournaments %}
+    <div class="">
+      <h3>Event Name: {{ tournament.event_name }}</h3>
+      <ul>
+        <li>Start Date: {{ tournament.start_date }}</li>
+        <li>Venue: {{ tournament.venue }}</li>
+        <li>Director: {{ tournament.director }}</li>
+        <li>Pairing: {{ tournament.pairing }}</li>
+        <li>Rules: {{ tournament.rule_set }}</li>
+      </ul>
+    </div>
+  {% endfor %}
+{% endblock content %}

--- a/web/app/tournament/tourny.py
+++ b/web/app/tournament/tourny.py
@@ -8,5 +8,5 @@ from app.models import db, Tournament
 @tournament.route('/')
 def index():
     tournaments = Tournament.query.all()
-    x = tournaments[0]
-    return x.event_name
+    return render_template('tournament_index.html',
+                    tournaments=tournaments,)

--- a/web/app/tournament/tourny.py
+++ b/web/app/tournament/tourny.py
@@ -1,6 +1,12 @@
-from flask import current_app
+
+from flask import current_app, render_template
+from flask import jsonify, request, Response
 from . import tournament
+from app.models import db, Tournament
+
 
 @tournament.route('/')
 def index():
-    return "Hello, World"
+    tournaments = Tournament.query.all()
+    x = tournaments[0]
+    return x.event_name

--- a/web/create_db.py
+++ b/web/create_db.py
@@ -2,10 +2,10 @@ import datetime
 import os
 import random
 
-from flask.ext.security.utils import encrypt_password 
+from flask.ext.security.utils import encrypt_password
 
 from app import get_app
-from app.models import user_datastore, Player, GoServer, Game, User, RATINGS_ADMIN_ROLE, SERVER_ADMIN_ROLE, USER_ROLE, db
+from app.models import user_datastore, Player, GoServer, Game, User, Tournament, RATINGS_ADMIN_ROLE, SERVER_ADMIN_ROLE, USER_ROLE, db
 
 # Create data for testing
 def create_test_data():
@@ -135,10 +135,26 @@ def create_extra_data():
     print("Saving games...")
     for g in games:
         db.session.add(g)
-    db.session.commit() 
+    db.session.commit()
     strongest = max(p_priors, key = lambda k: p_priors[k])
     strongest_games = [str(g) for g in games if g.white.user_id == strongest or g.black.user_id == strongest]
     print("Strongest, %d (%f):\n%s"% (strongest, p_priors[strongest], strongest_games))
+
+    def make_tournament():
+        t = Tournament(event_name="The Ultimate Go-ing Chamionship",
+                       start_date=datetime.datetime.now(),
+                       venue="LasVegas",
+                       director="Donald J. Trump",
+                       pairing="Completely Random - It's Madness!",
+                       rule_set="To the death!")
+        return t
+
+    print("Tournament...")
+    t = make_tournament()
+    print("Saving tournament...")
+    db.session.add(t)
+    db.session.commit()
+
 
 if __name__ == '__main__':
     app = get_app('config.DockerConfiguration')


### PR DESCRIPTION
Added simple tournament model and modified view to query db.
created a tournaments index page to display tournaments.
add a single tournament to the create_db.py file.
To see the Tournament at '/tournament' will require a rerunning create_db.py.
